### PR TITLE
Adding edit(ed)_term_taxonomy actions and a unit tests

### DIFF
--- a/lightweight-term-count-update.php
+++ b/lightweight-term-count-update.php
@@ -236,7 +236,16 @@ class LTCU_Plugin {
 						// Decrementing.
 						$update_query = "UPDATE {$wpdb->term_taxonomy} AS tt SET tt.count = tt.count - 1 WHERE tt.term_taxonomy_id IN $tt_ids_string AND tt.count > 0";
 					}
+
+					foreach( $tt_ids as $tt_id ) {
+						/** This action is documented in wp-includes/taxonomy.php */
+						do_action( 'edit_term_taxonomy', $tt_id, $taxonomy );
+					}
 					$wpdb->query( $update_query ); // WPCS: unprepared SQL ok.
+					foreach( $tt_ids as $tt_id ) {
+						/** This action is documented in wp-includes/taxonomy.php */
+						do_action( 'edited_term_taxonomy', $tt_id, $taxonomy );
+					}
 				}
 			}
 


### PR DESCRIPTION
Since we are updating more tt_ids at once, we need to fire the actions inside a loop. Not the best way to do it, but it seems to be necessary.

The test for testing the action is inspired by https://core.trac.wordpress.org/browser/trunk/tests/phpunit/tests/actions/closures.php when it comes to using the $GLOBALS